### PR TITLE
Modified spouse relations to go both directions (from person 1 to person 2 and from person 2 to person 1) to be more consistent with the behavior of sibling relationships.

### DIFF
--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -100,6 +100,16 @@ namespace GedcomParser.Parsers
                     Relation = relation,
                     Note = note
                 });
+                resultContainer.SpouseRelations.Add(new SpouseRelation
+                {
+                    FamilyId = famChunk.Id,
+                    From = parents[1],
+                    To = parents[0],
+                    Marriage = marriage,
+                    Divorce = divorce,
+                    Relation = relation,
+                    Note = note
+                });
             }
 
             // Parents / Children


### PR DESCRIPTION
Spouse relationships currently are only created in one direction (person 1 -> person 2). A sibling relationship is created in both directions (from person 1 to person 2 and from person 2 to person 1).