### PR TITLE
Fixed spouse relationships to go both ways

### DIFF
--- a/src/GedcomParser/Entities/Person.cs
+++ b/src/GedcomParser/Entities/Person.cs
@@ -16,6 +16,7 @@ namespace GedcomParser.Entities
         public DatePlace Baptized { get; set; }
         public string Education { get; set; }
         public string Religion { get; set; }
+        public string Nationality { get; set; }
         public string Note { get; set; }
         public string Changed { get; set; }
         public string Occupation { get; set; }

--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -143,8 +143,8 @@ namespace GedcomParser.Parsers
                     FamilyId = famChunk.Id,
                     From = parents[1],
                     To = parents[0],
-                    Marriage = marriage,
-                    Divorce = divorce,
+                    Marriage = spousalRelation.Marriage,
+                    Divorce = spousalRelation.Divorce,
                     Relation = relation,
                     Note = note
                 });

--- a/src/GedcomParser/Parsers/PersonParser.cs
+++ b/src/GedcomParser/Parsers/PersonParser.cs
@@ -146,6 +146,7 @@ namespace GedcomParser.Parsers
 
                     // Deliberately skipped for now
                     case "_GRP":
+                    case "_UPD":
                     case "CONF":
                     case "DSCR":
                     case "FAMS":

--- a/src/GedcomParser/Parsers/PersonParser.cs
+++ b/src/GedcomParser/Parsers/PersonParser.cs
@@ -104,6 +104,10 @@ namespace GedcomParser.Parsers
 
                         break;
 
+                    case "NATI":
+                        person.Nationality = chunk.Data;
+                        break;
+
                     case "NATU":
                         person.BecomingCitizen.Add(resultContainer.ParseDatePlace(chunk));
                         break;


### PR DESCRIPTION
Need initialize variables `marriage` and `divorce`.
I guess you mean
`Marrige = marriage` as `Marriage = spousalRelation.Marriage`, and
`Divorce = divorce` as `Divorce = spousalRelation.Divorce`.