### PR TITLE
Added '_UID', '_UPD', 'RIN' (family) tags

### DIFF
--- a/src/GedcomParser/Entities/Person.cs
+++ b/src/GedcomParser/Entities/Person.cs
@@ -16,6 +16,7 @@ namespace GedcomParser.Entities
         public DatePlace Baptized { get; set; }
         public string Education { get; set; }
         public string Religion { get; set; }
+        public string Nationality { get; set; }
         public string Note { get; set; }
         public string Changed { get; set; }
         public string Occupation { get; set; }

--- a/src/GedcomParser/Entities/Relation.cs
+++ b/src/GedcomParser/Entities/Relation.cs
@@ -5,6 +5,7 @@ namespace GedcomParser.Entities
     public abstract class Relation
     {
         public string FamilyId { get; set; }
+        public string FamilyUid { get; set; }
         public Person From { get; set; }
         public Person To { get; set; }
     }

--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -143,8 +143,8 @@ namespace GedcomParser.Parsers
                     FamilyId = famChunk.Id,
                     From = parents[1],
                     To = parents[0],
-                    Marriage = marriage,
-                    Divorce = divorce,
+                    Marriage = spousalRelation.Marriage,
+                    Divorce = spousalRelation.Divorce,
                     Relation = relation,
                     Note = note
                 });

--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -108,6 +108,7 @@ namespace GedcomParser.Parsers
                     case "NMR":
                     case "OBJE":
                     case "PAGE":
+                    case "RIN":
                     case "SOUR":
                         resultContainer.Warnings.Add($"Skipped Family Type='{chunk.Type}'");
                         break;

--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -14,6 +14,7 @@ namespace GedcomParser.Parsers
             var spousalRelation = new SpouseRelation();
             string relation = null;
             string note = null;
+            string uid = null;
             var parents = new List<Person>();
             var children = new List<Person>();
 
@@ -21,6 +22,10 @@ namespace GedcomParser.Parsers
             {
                 switch (chunk.Type)
                 {
+                    case "_UID":
+                        uid = chunk.Data;
+                        break;
+
                     case "CHIL":
                         var child = resultContainer.Persons.SingleOrDefault(p => p.Id == chunk.Reference);
                         if (child != null)
@@ -125,6 +130,7 @@ namespace GedcomParser.Parsers
                 resultContainer.SpouseRelations.Add(new SpouseRelation
                 {
                     FamilyId = famChunk.Id,
+                    FamilyUid = uid,
                     From = parents[0],
                     To = parents[1],
                     Engagement          = spousalRelation.Engagement,
@@ -143,6 +149,7 @@ namespace GedcomParser.Parsers
                 resultContainer.SpouseRelations.Add(new SpouseRelation
                 {
                     FamilyId = famChunk.Id,
+                    FamilyUid = uid,
                     From = parents[1],
                     To = parents[0],
                     Marriage = spousalRelation.Marriage,

--- a/src/GedcomParser/Parsers/FamilyParser.cs
+++ b/src/GedcomParser/Parsers/FamilyParser.cs
@@ -97,6 +97,7 @@ namespace GedcomParser.Parsers
                         break;
 
                     // Deliberately skipped for now
+                    case "_UPD":
                     case "CHAN":
                     case "DSCR":
                     case "EVEN":

--- a/src/GedcomParser/Parsers/PersonParser.cs
+++ b/src/GedcomParser/Parsers/PersonParser.cs
@@ -146,6 +146,7 @@ namespace GedcomParser.Parsers
 
                     // Deliberately skipped for now
                     case "_GRP":
+                    case "_UPD":
                     case "CONF":
                     case "DSCR":
                     case "FAMS":

--- a/src/GedcomParser/Parsers/PersonParser.cs
+++ b/src/GedcomParser/Parsers/PersonParser.cs
@@ -104,6 +104,10 @@ namespace GedcomParser.Parsers
 
                         break;
 
+                    case "NATI":
+                        person.Nationality = chunk.Data;
+                        break;
+
                     case "NATU":
                         person.BecomingCitizen.Add(resultContainer.ParseDatePlace(chunk));
                         break;


### PR DESCRIPTION
_UID (unique identifier), _UPD (update) - tags for common GEDCOM extensions supported by a fairly large number of different products from different vendors.
RIN (record id) - A number assigned to a record by an originating automated system that can be used by a
receiving system to report results pertaining to that record.